### PR TITLE
Speed up downloads

### DIFF
--- a/windows/install-docker-ce.ps1
+++ b/windows/install-docker-ce.ps1
@@ -1,4 +1,5 @@
 
+$ProgressPreference = 'SilentlyContinue'
 $response = Invoke-WebRequest -UseBasicParsing https://api.github.com/repos/moby/moby/releases/latest
 $content = $response.Content
 $latest = ConvertFrom-Json $content

--- a/windows/install-docker-compose.ps1
+++ b/windows/install-docker-compose.ps1
@@ -1,4 +1,5 @@
 
+$ProgressPreference = 'SilentlyContinue'
 $response = Invoke-WebRequest -UseBasicParsing https://api.github.com/repos/docker/compose/releases/latest
 $content = $response.Content
 $latest = ConvertFrom-Json $content


### PR DESCRIPTION
Added `$ProgressPreference = 'SilentlyContinue'` to the Windows download scripts to improve download speed. This is one of the lessons learned in several Dockerfiles ;-)

Without that flag, the progress bar in the PowerShell windows is slowing down the download and unzip to 41 seconds:

```
PS C:\Windows\system32> measure-command { iwr -useb https://raw.githubusercontent.com/sixeyed/docker-init/master/windows/install-docker-ce.ps1 | iex }


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 41
Milliseconds      : 425
Ticks             : 414254267
TotalDays         : 0.000479460957175926
TotalHours        : 0.0115070629722222
TotalMinutes      : 0.690423778333333
TotalSeconds      : 41.4254267
TotalMilliseconds : 41425.4267
```


Without that progress bar download + unzip only takes 5 seconds:

```
PS C:\Windows\system32> $ProgressPreference = 'SilentlyContinue'
PS C:\Windows\system32> measure-command { iwr -useb https://raw.githubusercontent.com/sixeyed/docker-init/master/windows/install-docker-ce.ps1 | iex }


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 5
Milliseconds      : 212
Ticks             : 52120764
TotalDays         : 6.03249583333333E-05
TotalHours        : 0.001447799
TotalMinutes      : 0.08686794
TotalSeconds      : 5.2120764
TotalMilliseconds : 5212.0764
```
