### PR TITLE
Shorten Windows commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Init scripts for setting up and prepping Docker environments
 Install latest Docker CE - stops and restarts Windows Service if installed, but does not register service if not:
 
 ```
-Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/sixeyed/docker-init/master/windows/install-docker-ce.ps1'))
+iwr -useb https://raw.githubusercontent.com/sixeyed/docker-init/master/windows/install-docker-ce.ps1 | iex
 ```
 
 Install latest Docker Compose - downloads to Docker path:
 
 ```
-Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/sixeyed/docker-init/master/windows/install-docker-compose.ps1'))
+iwr -useb https://raw.githubusercontent.com/sixeyed/docker-init/master/windows/install-docker-compose.ps1 | iex
 ```
 
-## Ubuntu 
+## Ubuntu
 
 Install latest Docker CE - inludes init system setup:
 


### PR DESCRIPTION
The shorter PowerShell commands to run the ps1 from the web are more likely to fit to the user's screen without scrolling.
