### PR TITLE
Add CHANNEL variable to test release candidates

### DIFF
--- a/ubuntu/install-docker-ce.sh
+++ b/ubuntu/install-docker-ce.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
+CHANNEL=${CHANNEL:-edge}
+
 sudo apt-get -y install \
   apt-transport-https \
   ca-certificates \
   curl
+
+sudo apt-get remove -y docker-engine docker.io || true
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 
 sudo add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
        $(lsb_release -cs) \
-       edge"
+       $CHANNEL"
 
 sudo apt-get update
 


### PR DESCRIPTION
To test eg. 17.06.0-ce-rc2 I added a CHANNEL variable to switch to test channel.

```
curl -sSL https://raw.githubusercontent.com/sixeyed/docker-init/master/ubuntu/install-docker-ce.sh | CHANNEL=test sh
```

The default is edge, it is also usable to switch to stable channel.
